### PR TITLE
epdfview: remove hard dependency on lcms

### DIFF
--- a/apps/epdfview/DEPENDS
+++ b/apps/epdfview/DEPENDS
@@ -1,6 +1,5 @@
 depends  gtk+-2
 depends  poppler
-depends  lcms
 
 optional_depends  "cups"  "--with-cups"  "--without-cups"  \
                   "for CUPS based printing support"


### PR DESCRIPTION
This is no dependency at all for epdfview

Thanks to tchan for noticing.
